### PR TITLE
Fix compile error on Xcode26

### DIFF
--- a/Example/Tests/Tests/ZDAllTests.m
+++ b/Example/Tests/Tests/ZDAllTests.m
@@ -200,7 +200,6 @@ typedef NS_ENUM(NSInteger, ZDMPriority) {
     XCTAssertNotNil(cat);
     
     [ZDMOneForAll removeService:@protocol(CatProtocol) priority:ZDMDefaultPriority autoInitAgain:NO];
-    id v = ZDMGetService(CatProtocol);
     XCTAssertNil(ZDMGetService(CatProtocol));
     
     NSString *name = [ZDMGetService(CatProtocol) name];

--- a/Sources/Classes/Public/ZDMOneForAll.m
+++ b/Sources/Classes/Public/ZDMOneForAll.m
@@ -279,22 +279,18 @@ NS_INLINE NSString *zdmStoreKey(NSString *serviceName, NSNumber *priority) {
              priority:(NSInteger)priority
         autoInitAgain:(BOOL)autoInitAgain {
     if (!serviceProtocol) {
-#if DEBUG
-        NSLog(@"❌ >>>>> the protocol is nil");
-#if ENABLE_ASSERT
+        ZDMLog(@"❌ >>>>> the protocol is nil");
+#if DEBUG && ENABLE_ASSERT
         NSAssert(NO, @"the protocol is nil");
-#endif
 #endif
         return NO;
     }
     
     NSString *serviceName = NSStringFromProtocol(serviceProtocol);
     if (!serviceName) {
-#if DEBUG
-        NSLog(@"❌ >>>>> the protocol name is nil");
-#if ENABLE_ASSERT
+        ZDMLog(@"❌ >>>>> the protocol name is nil");
+#if DEBUG && ENABLE_ASSERT
         NSAssert(NO, @"the protocol name is nil");
-#endif
 #endif
         return NO;
     }
@@ -664,6 +660,7 @@ NS_INLINE NSString *zdmStoreKey(NSString *serviceName, NSNumber *priority) {
     // Fault tolerance
     // 假如用默认优先级来取,并且集合中不存在的话,说明未注册,此时则取集合中优先级最高的那个优先级来代替
     if (priority == ZDMDefaultPriority && ![prioritySet containsObject:@(priority)] && prioritySet.count > 0) {
+        ZDMLog(@"❌ >>>>> not found service for protocol: (%@)", serviceName);
         priority = prioritySet.firstObject.integerValue;
     }
     NSString *key = zdmStoreKey(serviceName, @(priority));
@@ -672,7 +669,7 @@ NS_INLINE NSString *zdmStoreKey(NSString *serviceName, NSNumber *priority) {
     ZDMServiceBox *box = mediator.registerInfoDict[key];
     [mediator.lock unlock];
     if (!box) {
-        NSLog(@"❌ >>>>> please register a class first");
+        ZDMLog(@"❌ >>>>> please register a class first for protocol: (%@)", serviceName);
         return nil;
     }
     
@@ -687,7 +684,7 @@ NS_INLINE NSString *zdmStoreKey(NSString *serviceName, NSNumber *priority) {
     }
     
     if (!serviceInstance) {
-        NSLog(@"❌ >>>>> Finally, the instance object of service: (%@), priority: (%zd) was not found", serviceName, priority);
+        ZDMLog(@"❌ >>>>> Finally, the instance object of service: (%@), priority: (%zd) was not found", serviceName, priority);
     }
     
     // prevent crashes
@@ -710,7 +707,7 @@ NS_INLINE NSString *zdmStoreKey(NSString *serviceName, NSNumber *priority) {
 + (id)_createInstance:(ZDMServiceBox *)innerBox {
     Class aCls = innerBox.cls;
     if (!aCls) {
-        NSLog(@"❌ >>>>> %d, %s => please register first", __LINE__, __FUNCTION__);
+        ZDMLog(@"❌ >>>>> %d, %s => please register first", __LINE__, __FUNCTION__);
         return nil;
     }
     

--- a/Sources/Classes/Public/ZDMediatorDefine.h
+++ b/Sources/Classes/Public/ZDMediatorDefine.h
@@ -14,6 +14,16 @@
 // 1v1 priority
 static NSInteger const ZDMDefaultPriority = 0;
 
+#if DEBUG
+#ifndef ZDMLog
+#define ZDMLog(...) NSLog(@"❌❌❌" __VA_ARGS__);
+#endif
+#else
+#ifndef ZDMLog
+#define ZDMLog(...)
+#endif
+#endif
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 // 参数不能为bool类型，因为会报错

--- a/Sources/Classes/Public/ZDMediatorDefine.h
+++ b/Sources/Classes/Public/ZDMediatorDefine.h
@@ -11,8 +11,10 @@
 #import <Foundation/Foundation.h>
 #import <mach-o/loader.h>
 
-// 1v1 priority
-static NSInteger const ZDMDefaultPriority = 0;
+/// 1v1 priority
+#ifndef ZDMDefaultPriority
+#define ZDMDefaultPriority ((NSInteger)0)
+#endif
 
 #if DEBUG
 #ifndef ZDMLog
@@ -36,8 +38,10 @@ typedef id (^ZDMCommonCallback)();
 struct ZDMMachoOFARegisterKV {
     const char *key;
     const char *value;
-    const int autoInit;     ///< 0,1
-    const int allClsMethod; ///< 0,1
+    /// 0,1
+    const int autoInit;
+    /// 0,1
+    const int allClsMethod;
     const int priority;
 };
 

--- a/Sources/Classes/Public/ZDMediatorDefine.h
+++ b/Sources/Classes/Public/ZDMediatorDefine.h
@@ -31,14 +31,6 @@ static NSInteger const ZDMDefaultPriority = 0;
 typedef id (^ZDMCommonCallback)();
 #pragma clang diagnostic pop
 
-#ifndef ZDMIGNORE_SELWARNING
-#define ZDMIGNORE_SELWARNING(...)                                              \
-  _Pragma("clang diagnostic push")                                             \
-  _Pragma("clang diagnostic ignored \"-Wundeclared-selector\"")                \
-    __VA_ARGS__                                                                \
-  _Pragma("clang diagnostic pop")
-#endif
-
 //-------------------------One For All------------------------------
 
 struct ZDMMachoOFARegisterKV {

--- a/ZDMediator.podspec
+++ b/ZDMediator.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ZDMediator'
-  s.version          = '0.4.2'
+  s.version          = '0.4.3'
   s.summary          = '模块通信中间件'
   s.description      = <<-DESC
     用于模块间通信的中间件，支持自动注册、手动注册、强弱引用、实例方法、类方法调用


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a debug-only logging macro to simplify consistent runtime logs.

- Refactor
  - Standardized internal logging to the new macro and tightened assertion guards.
  - Updated default-priority definition (no behavioral change).
  - Removed a legacy macro for selector-warning suppression.

- Documentation
  - Clarified field comments in a public struct (no API signature changes).

- Tests
  - Simplified a test by removing an unused variable (no behavior change).

- Chores
  - Bumped package version to 0.4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->